### PR TITLE
feat: Automatic complex shared values collections management

### DIFF
--- a/example/app/src/App.tsx
+++ b/example/app/src/App.tsx
@@ -1,5 +1,5 @@
-import AnimatedIntervalExample from './examples/AnimatedInterval';
+import ComplexSharedValues from './examples/ComplexSharedValues';
 
 export default function App() {
-  return <AnimatedIntervalExample />;
+  return <ComplexSharedValues />;
 }

--- a/packages/reanimated-utils/package.json
+++ b/packages/reanimated-utils/package.json
@@ -60,7 +60,7 @@
     "build": "yarn clean && bob build",
     "clean": "../../scripts/clean.sh",
     "postpack": "rm ./README.md",
-    "prepack": "bob build && cp ../../README.md ./README.md",
+    "prepack": "bob build && rm -f *.tgz && cp ../../README.md ./README.md",
     "test": "jest",
     "typecheck": "tsc -p tsconfig.json --noEmit"
   },

--- a/packages/reanimated-utils/src/hooks/useComplexSharedValues/index.ts
+++ b/packages/reanimated-utils/src/hooks/useComplexSharedValues/index.ts
@@ -1,5 +1,6 @@
 export type {
   ArrayMethods,
+  ComplexSharedValuesReturnType as ComplexSharedValues,
   ComplexValue,
   RecordMethods,
   SchemaArray,

--- a/packages/reanimated-utils/src/hooks/useComplexSharedValues/types.ts
+++ b/packages/reanimated-utils/src/hooks/useComplexSharedValues/types.ts
@@ -118,7 +118,9 @@ type ConvertToSchemaOutsideMutable<T> =
               | [ConvertToSchemaOutsideMutable<U>]
               | SchemaArray<ConvertToSchemaOutsideMutable<U>>
         : IsInfiniteObject<T> extends true
-          ? SchemaRecord<ConvertToSchemaOutsideMutable<T[keyof T]>>
+          ?
+              | { $key: ConvertToSchemaOutsideMutable<T[keyof T]> }
+              | SchemaRecord<ConvertToSchemaOutsideMutable<T[keyof T]>>
           : T extends Record<string, any>
             ?
                 | {
@@ -141,7 +143,9 @@ type ConvertToSchemaInsideMutable<T> =
             | [ConvertToSchemaInsideMutable<U>]
             | SchemaArray<ConvertToSchemaInsideMutable<U>>
       : IsInfiniteObject<T> extends true
-        ? SchemaRecord<ConvertToSchemaInsideMutable<T[keyof T]>>
+        ?
+            | { $key: ConvertToSchemaInsideMutable<T[keyof T]> }
+            | SchemaRecord<ConvertToSchemaInsideMutable<T[keyof T]>>
         : T extends Record<string, any>
           ?
               | {
@@ -199,6 +203,17 @@ type MethodType<V> =
     : IsInfiniteObject<V> extends true
       ? RecordMethods<V>
       : SingletonMethods<V>;
+
+export type DepsType<V> =
+  IsInfiniteArray<V> extends true
+    ? number // items count in the top level array
+    : V extends SchemaArray<any>
+      ? number
+      : IsInfiniteObject<V> extends true
+        ? Array<string> // keys of the top level object
+        : V extends SchemaRecord<any>
+          ? Array<string>
+          : never;
 
 export type ComplexSharedValuesReturnType<V> = Simplify<
   {

--- a/packages/reanimated-utils/src/hooks/useComplexSharedValues/useComplexSharedValues.ts
+++ b/packages/reanimated-utils/src/hooks/useComplexSharedValues/useComplexSharedValues.ts
@@ -7,6 +7,7 @@ import { useRef } from 'react';
 import type {
   ComplexSharedValuesReturnType,
   ComplexSharedValuesSchema,
+  DepsType,
   SingletonSchema
 } from './types';
 import { useComplexSharedValuesArray } from './useComplexSharedValuesArray';
@@ -19,17 +20,20 @@ import {
   type SchemaFactory
 } from './utils';
 
-// Function overloads
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export function useComplexSharedValues<F extends SchemaFactory>(
+  schema: F,
+  deps?: DepsType<ReturnType<F>>
+): ComplexSharedValuesReturnType<ReturnType<F>>;
+
 export function useComplexSharedValues<V>(
-  schema: SchemaFactory<V>
+  schema: ComplexSharedValuesSchema<V> | SchemaFactory<V>,
+  deps?: DepsType<V>
 ): ComplexSharedValuesReturnType<V>;
 
 export function useComplexSharedValues<V>(
-  schema: ComplexSharedValuesSchema<V>
-): ComplexSharedValuesReturnType<V>;
-
-export function useComplexSharedValues<V>(
-  schema: ComplexSharedValuesSchema<V> | SchemaFactory<V>
+  schema: ComplexSharedValuesSchema<V> | SchemaFactory<V>,
+  deps?: DepsType<V>
 ): ComplexSharedValuesReturnType<V> {
   const schemaRef = useRef<ComplexSharedValuesSchema<V>>();
 
@@ -52,10 +56,16 @@ export function useComplexSharedValues<V>(
   }
 
   if (isArraySchema(currentSchema)) {
-    return useComplexSharedValuesArray(currentSchema);
+    return useComplexSharedValuesArray(
+      currentSchema,
+      deps as number | undefined
+    );
   }
   if (isRecordSchema(currentSchema)) {
-    return useComplexSharedValuesRecord(currentSchema);
+    return useComplexSharedValuesRecord(
+      currentSchema,
+      deps as Array<string> | undefined
+    );
   }
   return useComplexSharedValuesSingleton(currentSchema as SingletonSchema);
 }

--- a/packages/reanimated-utils/src/hooks/useComplexSharedValues/useComplexSharedValuesArray.ts
+++ b/packages/reanimated-utils/src/hooks/useComplexSharedValues/useComplexSharedValuesArray.ts
@@ -2,7 +2,7 @@
 /* eslint-disable @typescript-eslint/no-unsafe-return */
 /* eslint-disable @typescript-eslint/no-explicit-any */
 
-import { useCallback, useMemo } from 'react';
+import { useCallback, useMemo, useRef } from 'react';
 
 import { useCurrentValue } from './hooks';
 import {
@@ -26,7 +26,8 @@ function isSchemaArray(obj: any): obj is SchemaArray<any> {
 }
 
 export function useComplexSharedValuesArray<V>(
-  arraySchema: ArraySchema
+  arraySchema: ArraySchema,
+  dep?: number
 ): ComplexSharedValuesReturnType<V> {
   const schema = isSchemaArray(arraySchema)
     ? arraySchema.defaultValue
@@ -193,6 +194,20 @@ export function useComplexSharedValuesArray<V>(
     },
     [current, schema]
   );
+
+  /**
+   * Update the array based on the dependencies
+   */
+  const prevDepRef = useRef(dep);
+  if (dep !== undefined && dep !== prevDepRef.current) {
+    if (dep > current.length) {
+      push(dep - current.length);
+    } else if (dep < current.length) {
+      splice(dep);
+    }
+
+    prevDepRef.current = dep;
+  }
 
   return useMemo<{ current: Record<string, any> } & ArrayMethods<V>>(
     () => ({

--- a/packages/reanimated-utils/src/hooks/useComplexSharedValues/utils.ts
+++ b/packages/reanimated-utils/src/hooks/useComplexSharedValues/utils.ts
@@ -54,7 +54,7 @@ export const object = <V>(defaultValue: V): SchemaObject<V> => ({
   defaultValue
 });
 
-export type SchemaFactory<V> = (args: {
+export type SchemaFactory<V = any> = (args: {
   mutable: typeof mutable;
   tuple: typeof tuple;
   array: typeof array;


### PR DESCRIPTION
## Description

This PR adds automatic shared valeus management. 

For the record schema, the array of record item keys can be provided to automatically create/remove objects in the record based on the provided schema.

For the array schema, the number of items can be provided, to automatically create/remove array entries based on the porvidded schema.

## Examples

- **record** schema

```tsx
const [keys, setKeys] = useState<Array<string>>([]);

const dimensions = useComplexSharedValues(
  s => s.record(s.mutable({ height: 0, width: 0 })),
  keys // when keys in state change, dimensions record is updated respectively
);
```

- **array** schema

```tsx
const [rowCount, setRowCount] = useState(0);

const rowOffsets = useComplexSharedValues(
  s => s.array(s.mutable(0)),
  rowCount // then the row count changes, the number of entries in the array is modified
);
```

## Remarks

- already existing objects aren't removed
  - for **record**, that means that only affected keys which are no longer present in the dependencies array will be removed and new objects will be added only for new keys. Items, which existed for keys that were unaffected, aren't modified,
  - for **array**, that means the only items from indexes greater than the new array length (if the array schrnks) or greater than the previous array length (if it expands) will be modified.
